### PR TITLE
Connection timeout can't be overriden in the ini file

### DIFF
--- a/classes/VarnishPurger.php
+++ b/classes/VarnishPurger.php
@@ -27,12 +27,13 @@ class VarnishPurger
 		$ini_varnish = eZINI::instance( 'mugo_varnish.ini' );
 		$this->debug               = $ini_varnish->variable( 'VarnishSettings', 'DebugCurl' ) == 'enabled';
 		$this->varnishServers      = $ini_varnish->variable( 'VarnishSettings', 'VarnishServers' );
-		
+				
 		// override connection timeout
-		if( $ini_varnish->variable( 'VarnishSettings', 'ConnectionTimeout' ) > -1 )
+		if( ( $connectionTimeout = $ini_varnish->variable( 'VarnishSettings', 'ConnectionTimeout' ) ) > -1 )
 		{
-			$this->baseCurlOptions[ CURLOPT_CONNECTTIMEOUT ] = $this->connectionTimeout;
+			$this->baseCurlOptions[ CURLOPT_CONNECTTIMEOUT ] = $connectionTimeout;
 		}
+		
 		
 		// make sure the log file exits
 		if( !file_exists( self::CURL_DEBUG_OUTPUT_FILE ) )


### PR DESCRIPTION
I fixed a little bug so that the connection timeout can now be overriden in the ini file and the PHP Notice "Undefined property: VarnishPurger::$connectionTimeout" is no longer thrown.
